### PR TITLE
Added RE Conferences

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -699,7 +699,7 @@
   deadline: ["TBA"]
   date: April 28 - April 29, 2025 with ICSE 2025
   place: Ottawa, Ontario, Canada
-  tags: [CO, NIER]  tags: [CO, NIER]
+  tags: [CO, NIER]
 
 - name: RE-RP
   description: Requirements Engineering - Research Papers
@@ -713,3 +713,14 @@
   note: Mandatory abstract deadline on March 3rd (first deadline) and paper deadline on March 10th (second deadline)
   tags: [RPT]
 
+- name: REFSQ-RT
+  description: Requirements Engineering Foundation for Software Quality - Research Track
+  year: 2025
+  link: https://2025.refsq.org/track/refsq-2025-research-papers
+  deadline:
+   - "2024-11-01 23:59"
+   - "2024-11-08 23:59"
+  date: April 7 - April 10, 2025
+  place: Barcelona, Catalunya, Spain
+  note: Mandatory abstract deadline on November 1st (first deadline) and paper deadline on November 8th (second deadline)
+  tags: [RPT]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -699,4 +699,17 @@
   deadline: ["TBA"]
   date: April 28 - April 29, 2025 with ICSE 2025
   place: Ottawa, Ontario, Canada
-  tags: [CO, NIER]
+  tags: [CO, NIER]  tags: [CO, NIER]
+
+- name: RE-RP
+  description: Requirements Engineering - Research Papers
+  year: 2025
+  link: https://conf.researchr.org/track/RE-2025/RE-2025-Research-Papers
+  deadline:
+   - "2025-03-03 23:59"
+   - "2025-03-10 23:59"
+  date: September 1 - September 5, 2025
+  place: Valencia, Spain
+  note: Mandatory abstract deadline on March 3rd (first deadline) and paper deadline on March 10th (second deadline)
+  tags: [RPT]
+


### PR DESCRIPTION
This PR adds information about the 2025 instances of the two main requirements engineering conferences, the [Requirements Engineering](https://conf.researchr.org/home/RE-2025) (RE) conference and the [Requirements Engineering: Foundation for Software Quality](https://2025.refsq.org/track/refsq-2025-research-papers) (REFSQ) conference. In both cases, only the main research paper track (`RPT`) has been added.