### PR TITLE
Add EASE 2025 (Research Paper Track)

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1077,3 +1077,14 @@
   place: Brugg - Windisch, Switzerland
   note: Recommended abstract deadline on January 19, 2025
   tags: [CO, RPT]
+
+name: EASE-RPT
+  description: International Conference on Agile Software Development - Research Track
+  year: 2025
+  link: https://conf.researchr.org/home/ease-2025
+  deadline:
+   - "2025-01-19 23:59"
+  date: June 17 - June 20, 2025
+  place: Istanbul, Turkey
+  note: Abstract deadline on January 12, 2025
+  tags: [CO, RPT]

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1079,7 +1079,7 @@
   tags: [CO, RPT]
 
 name: EASE-RPT
-  description: International Conference on Agile Software Development - Research Track
+  description: The International Conference on Evaluation and Assessment in Software Engineering (EASE) - Research Track
   year: 2025
   link: https://conf.researchr.org/home/ease-2025
   deadline:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1076,4 +1076,4 @@
   date: June 2 - June 5, 2025
   place: Brugg - Windisch, Switzerland
   note: Recommended abstract deadline on January 19, 2025
-  tags: [RPT]
+  tags: [CO, RPT]


### PR DESCRIPTION
Proposing the EASE 2025 Conference (Research Paper Track): https://conf.researchr.org/home/ease-2025
The conference includes additional tracks, but descriptions and deadlines for these are not available yet.