### PR TITLE
Add VehicleSec 2025

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -1267,3 +1267,11 @@
   deadline: 
   - "2025-01-15 23:59"
   tags: [JO]
+  
+  - name: VehicleSec
+  description: USENIX Vehicle Security and Privacy
+  year: 2025
+  link: https://www.usenix.org/conference/vehiclesec25/call-for-papers
+  deadline: 
+  - "2025-02-27 23:59"
+  tags: [CO]


### PR DESCRIPTION
I would like to add VehicleSec 2025 conference.

VehicleSec is the third symposium on Vehicle Security and Privacy that will be co-located with USENIX Security. Even though the conference name highlights security, the conference is also open to receiving software engineering works. 

Thank you!